### PR TITLE
Add database init script

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,15 @@ CREATE TABLE logs (
     FOREIGN KEY (usuario_id) REFERENCES usuarios(id) ON DELETE SET NULL
 );
 ```
+
+### 🔹 Criando as tabelas automaticamente
+Para criar todas as tabelas necessárias em uma nova instalação, execute o script:
+
+```bash
+php scripts/create_tables.php
+```
+
+O script verifica e cria cada tabela somente se ela ainda não existir.
 ---
 
 ## 📌 Estrutura de Diretórios
@@ -109,6 +118,9 @@ Rechlytics/
 │   ├── session_check.php  # Validação de sessão para usuários
 │   └── session_check_admin.php  # Validação de sessão para admins
 │
+├── scripts/          # Scripts auxiliares
+│   └── create_tables.php  # Criação das tabelas
+
 ├── vendor/            # Dependências do Composer (PHPMailer, etc.)
 │
 └── views/             # Páginas da interface do usuário

--- a/scripts/create_tables.php
+++ b/scripts/create_tables.php
@@ -1,0 +1,60 @@
+<?php
+// Script para criar tabelas do banco de dados para o Rechlytics
+// Execute este arquivo uma vez para inicializar o banco de dados
+
+require __DIR__ . '/../config/db.php';
+
+$queries = [];
+$queries[] = "CREATE TABLE IF NOT EXISTS usuarios (
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    nome VARCHAR(100) NOT NULL,
+    email VARCHAR(150) UNIQUE NOT NULL,
+    senha VARCHAR(255) NOT NULL,
+    telefone VARCHAR(20) NULL,
+    cpf VARCHAR(14) UNIQUE NULL,
+    empresa VARCHAR(150) NULL,
+    endereco TEXT NULL,
+    tipo ENUM('admin', 'cliente') NOT NULL DEFAULT 'cliente',
+    email_verificado TINYINT(1) DEFAULT 0,
+    two_factor_code VARCHAR(6) NULL,
+    two_factor_expira DATETIME NULL,
+    data_criacao TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4";
+
+$queries[] = "CREATE TABLE IF NOT EXISTS dashboards (
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    usuario_id INT NOT NULL,
+    nome VARCHAR(255) NOT NULL,
+    url TEXT NOT NULL,
+    FOREIGN KEY (usuario_id) REFERENCES usuarios(id) ON DELETE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4";
+
+$queries[] = "CREATE TABLE IF NOT EXISTS mensagens (
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    usuario_id INT NOT NULL,
+    mensagem TEXT NOT NULL,
+    data_envio TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    lida TINYINT(1) DEFAULT 0,
+    FOREIGN KEY (usuario_id) REFERENCES usuarios(id) ON DELETE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4";
+
+$queries[] = "CREATE TABLE IF NOT EXISTS logs (
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    usuario_id INT NULL,
+    acao TEXT NOT NULL,
+    data TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    FOREIGN KEY (usuario_id) REFERENCES usuarios(id) ON DELETE SET NULL
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4";
+
+foreach ($queries as $sql) {
+    try {
+        $conn->query($sql);
+        echo "Comando executado com sucesso: \n$sql\n\n";
+    } catch (Exception $e) {
+        echo "Erro ao executar comando: \n$sql\n\n";
+        echo $e->getMessage() . "\n";
+    }
+}
+
+echo "Concluído.";
+


### PR DESCRIPTION
## Summary
- add a PHP script for creating required tables
- document how to run the creation script and list it in the project directory structure

## Testing
- `php -l scripts/create_tables.php` *(fails: php not found)*

------
https://chatgpt.com/codex/tasks/task_e_683f585e661c832bb1c122bab6a8c6a6