### PR TITLE
Fix missing reset_token columns

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,8 +51,19 @@ CREATE TABLE usuarios (
     email_verificado TINYINT(1) DEFAULT 0,
     two_factor_code VARCHAR(6) NULL,
     two_factor_expira DATETIME NULL,
+    reset_token VARCHAR(64) NULL,
+    reset_token_expira DATETIME NULL,
     data_criacao TIMESTAMP DEFAULT CURRENT_TIMESTAMP
 );
+```
+
+Se você já possui a tabela `usuarios` criada sem as colunas de recuperação de senha,
+adicione-as executando:
+
+```sql
+ALTER TABLE usuarios
+    ADD reset_token VARCHAR(64) NULL,
+    ADD reset_token_expira DATETIME NULL;
 ```
 
 ### **🔹 Tabela `dashboards` (Gerencia os painéis do Power BI por cliente)**


### PR DESCRIPTION
## Summary
- add `reset_token` fields in the `usuarios` table docs
- document how to alter existing tables

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_683f8e0a7160832b8bb04f5207f31d63