### PR TITLE
Improve form styling

### DIFF
--- a/public/css/estilos.css
+++ b/public/css/estilos.css
@@ -1,6 +1,7 @@
 /* ================================
    RESET & BASE
    ================================ */
+@import url('https://fonts.googleapis.com/css2?family=Poppins:wght@400;600&display=swap');
 * {
     margin: 0;
     padding: 0;
@@ -13,7 +14,7 @@ html {
 }
 
 body {
-    font-family: Arial, sans-serif;
+    font-family: 'Poppins', Arial, sans-serif;
     background-color: #f4f4f4;
     color: #333;
     line-height: 1.6;
@@ -473,7 +474,50 @@ body {
         text-align: center;
     }
 
-    .footer-col {
+.footer-col {
         margin-bottom: 2rem;
     }
+}
+
+/* ================================
+   10. FORMULÁRIOS
+   ================================ */
+.form-auth {
+    max-width: 400px;
+    margin: 2rem auto;
+    background-color: #fff;
+    padding: 2rem;
+    border-radius: 8px;
+    box-shadow: 0 2px 8px rgba(0,0,0,0.1);
+}
+
+.form-auth label {
+    display: block;
+    font-weight: 600;
+    margin-bottom: 0.25rem;
+}
+
+.form-auth input {
+    width: 100%;
+    padding: 0.5rem;
+    border: 1px solid #ccc;
+    border-radius: 4px;
+    margin-bottom: 1rem;
+}
+
+.form-auth button {
+    display: block;
+    width: 100%;
+    padding: 0.75rem;
+    background-color: #007bff;
+    color: #fff;
+    border: none;
+    border-radius: 4px;
+    cursor: pointer;
+    font-weight: 600;
+    transition: background-color 0.3s;
+}
+
+.form-auth button:hover {
+    background-color: #0056b3;
 }

--- a/views/auth/esq_senha.php
+++ b/views/auth/esq_senha.php
@@ -118,7 +118,7 @@ if ($_SERVER["REQUEST_METHOD"] == "POST") {
         unset($_SESSION['msg']);
     }
     ?>
-    <form action="<?php echo htmlspecialchars($_SERVER['PHP_SELF']); ?>" method="POST">
+    <form action="<?php echo htmlspecialchars($_SERVER['PHP_SELF']); ?>" method="POST" class="form-auth">
         <label>Email:</label>
         <input type="email" name="email" required>
         <button type="submit">Enviar Link</button>

--- a/views/auth/redefinir_senha.php
+++ b/views/auth/redefinir_senha.php
@@ -123,7 +123,7 @@ if ($_SERVER["REQUEST_METHOD"] == "POST") {
     }
     ?>
 
-    <form action="<?php echo htmlspecialchars($_SERVER['PHP_SELF']) . '?token=' . urlencode($token); ?>" method="POST">
+    <form action="<?php echo htmlspecialchars($_SERVER['PHP_SELF']) . '?token=' . urlencode($token); ?>" method="POST" class="form-auth">
         <label>Nova Senha:</label>
         <input type="password" name="senha" required minlength="8">
 

--- a/views/auth/verificar_2fa.php
+++ b/views/auth/verificar_2fa.php
@@ -25,7 +25,7 @@ unset($_SESSION['erro_2fa']);
         <?php endif; ?>
 
         <!-- Aqui está a correção: subimos dois níveis para chegar em controllers/validar_2fa.php -->
-        <form action="../../controllers/validar_2fa.php" method="POST">
+        <form action="../../controllers/validar_2fa.php" method="POST" class="form-auth">
             <label for="codigo_2fa">Código 2FA:</label>
             <input type="text" id="codigo_2fa" name="codigo_2fa" required pattern="\d{6}"
                    title="Insira o código de 6 dígitos enviado por e-mail">

--- a/views/cadastro.php
+++ b/views/cadastro.php
@@ -81,7 +81,7 @@ if ($_SERVER["REQUEST_METHOD"] == "POST") {
     }
     ?>
 
-    <form action="<?php echo htmlspecialchars($_SERVER['PHP_SELF']); ?>" method="POST">
+    <form action="<?php echo htmlspecialchars($_SERVER['PHP_SELF']); ?>" method="POST" class="form-auth">
         <label>Nome:</label>
         <input type="text" name="nome" required>
 

--- a/views/login.php
+++ b/views/login.php
@@ -19,7 +19,7 @@ unset($_SESSION['erro_login']);
             <div class="erro"><?php echo htmlspecialchars($mensagem_erro); ?></div>
         <?php endif; ?>
 
-        <form action="../controllers/auth.php" method="POST">
+        <form action="../controllers/auth.php" method="POST" class="form-auth">
             <label for="email">E-mail:</label>
             <input type="email" id="email" name="email" required autocomplete="off">
 


### PR DESCRIPTION
## Summary
- use Google Poppins font
- add `.form-auth` styles for modern forms
- apply `.form-auth` class to authentication forms

## Testing
- `php -v` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6842f95bde64832b86a47fb6985233a6